### PR TITLE
implemented reuse option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,98 @@
 # Persistent Counter provider for Terraform
 
-```
+This provider allows to assign unique, increasing integers to string keys
+maintaining the same value per key while the key stays assigned.
+
+## Example
+
+```terraform
 terraform {
   required_providers {
     persistent = {
-      source = "rosmo/persistent"
+      source  = "rosmo/persistent"
+      version = ">=0.1.11"
     }
   }
 }
 
-resource "persistent_counter" "example" {
-  keys     = ["a", "b", "c"]
+variable input {
+  type = set(string)
 }
 
-# Result would be:
-#   persistent_counter.example.values = { a = 0, b = 1, c = 2 }
-
-# Changing the keys:
-resource "persistent_counter" "example" {
-  keys     = ["a", "b", "d", "c"]
+resource "persistent_counter" "with-reuse" {
+  initial_value = 1
+  keys          = var.input
+  reuse         = true
 }
 
-# New result would be:
-#   persistent_counter.example.values = { a = 0, b = 1, d = 3, c = 2 }
+resource "persistent_counter" "without-reuse" {
+  initial_value = 1
+  keys          = var.input
+  reuse         = false
+}
 
+output counters {
+  value = {
+    "with-reuse" = persistent_counter.with-reuse.values,
+    "without-reuse" = persistent_counter.without-reuse.values,
+  }
+}
 ```
 
-The provider is available from Terraform registry: [registry.terraform.io/providers/rosmo/persistent/latest](https://registry.terraform.io/providers/rosmo/persistent/latest)
+Run the example providing an initial value as input results in the following output:
+
+```shell
+$ terraform apply -auto-approve -var 'input=["c","b","a"]'
+
+counters = {
+  "with-reuse" = tomap({
+    "a" = 1
+    "b" = 2
+    "c" = 3
+  })
+  "without-reuse" = tomap({
+    "a" = 1
+    "b" = 2
+    "c" = 3
+  })
+}
+```
+
+If values were just added, both, the version with and without `reuse` enabled
+behave the same. Also note, that keys are always sorted ascending, before counter
+values are assigned to them.
+
+The difference the two versions in this example can be made clear when exchanging
+an element (i.e. removing a value and adding a new one at the same time):
+
+```shell
+$ terraform apply -auto-approve -var 'input=["c","a","d"]'
+
+counters = {
+  "with-reuse" = tomap({
+    "a" = 1
+    "c" = 3
+    "d" = 2
+  })
+  "without-reuse" = tomap({
+    "a" = 1
+    "c" = 3
+    "d" = 4
+  })
+}
+```
+
+When `reuse` is set to `true`, the counter will re-assign values that are no
+longer in use, while a value of `false` will always emit unique, ascending values.
+
+## Usage
+
+The provider is available from Terraform registry: [registry.terraform.io/providers/rosmo/persistent/latest](https://registry.terraform.io/providers/rosmo/persistent/latest).
 
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 1.0
-- [Go](https://golang.org/doc/install) >= 1.18
+- [Go](https://go.dev/doc/install) >= 1.21 (building from source only)
 
 ## Building The Provider
 
@@ -42,4 +103,3 @@ The provider is available from Terraform registry: [registry.terraform.io/provid
 ```shell
 go install
 ```
-

--- a/internal/provider/assignment.go
+++ b/internal/provider/assignment.go
@@ -1,0 +1,50 @@
+package provider
+
+import (
+	"slices"
+)
+
+// assignKeys assigns counter values to the keys provided as input
+func assignKeys(keys []string, state map[string]int64, reuse bool, initial int64, last int64) (int64, map[string]int64) {
+	// Create a map to hold the assigned values
+	assignedValues := make(map[string]int64, len(keys))
+	// Create a list of values for easier tracking for the next possible one
+	values := make([]int64, 0, len(keys))
+
+	// If the previous state is defined, maintain all entries that are still present in keys.
+	// Also handle a changing initial value.
+	for key, value := range state {
+		if slices.Contains(keys, key) && value >= initial {
+			assignedValues[key] = value
+			values = append(values, value)
+		}
+	}
+
+	// Sort keys to provide a predictable behaviour
+	slices.Sort(keys)
+
+	// Iterate over the keys and provide values to those not covered yet
+	for _, key := range keys {
+		// If the key has not yet a value assigned
+		if _, exists := assignedValues[key]; !exists {
+			// If reuse is true, find a value that does not exist in the assignedValues map
+			if reuse {
+				for i := initial; ; i++ {
+					if !slices.Contains(values, i) {
+						assignedValues[key] = i
+						values = append(values, i)
+						last = i
+						break
+					}
+				}
+			} else {
+				// If reuse is false, increment the last value and assign it to the key
+				last = max(last+1, initial)
+				assignedValues[key] = last
+			}
+		}
+	}
+
+	// Return the last value and the assignedValues map
+	return last, assignedValues
+}

--- a/internal/provider/assignment_test.go
+++ b/internal/provider/assignment_test.go
@@ -1,0 +1,82 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEmpty(t *testing.T) {
+	input := []string{}
+	initial := 5
+	last, res := assignKeys(input, nil, false, int64(initial), int64(initial))
+	t.Logf("input keys: %v, output: %v", input, res)
+	expectedLast := initial + len(input)
+	if last != int64(expectedLast) {
+		t.Errorf("Expecting last to be %d, got %d", expectedLast, last)
+	}
+	if len(res) != len(input) {
+		t.Errorf("Result map length %d != key length %d", len(res), len(input))
+	}
+}
+
+func TestInitial(t *testing.T) {
+	input := []string{"a", "c", "b"}
+	initial := 5
+	last, res := assignKeys(input, nil, false, int64(initial), int64(initial-1))
+	t.Logf("input keys: %v, output: %v", input, res)
+	expectedLast := initial + len(input) - 1
+	if last != int64(expectedLast) {
+		t.Errorf("Expecting last to be %d, got %d", expectedLast, last)
+	}
+	if len(res) != len(input) {
+		t.Errorf("Result map length %d != key length %d", len(res), len(input))
+	}
+	expected := map[string]int64{"a": 5, "b": 6, "c": 7}
+	if !reflect.DeepEqual(res, expected) {
+		t.Errorf("Expected %v got %v", expected, res)
+	}
+}
+
+func TestNop(t *testing.T) {
+	input := []string{"a", "c", "b"}
+	state := map[string]int64{"a": 5, "b": 9, "c": 11}
+	initial := 5
+	last := 11
+	last2, res := assignKeys(input, state, false, int64(initial), int64(last))
+	if !reflect.DeepEqual(res, state) {
+		t.Errorf("Expected %v got %v", state, res)
+	}
+	if int64(last) != last2 {
+		t.Errorf("Expected last value to stay at %d but got %d", last, last2)
+	}
+	last2, res = assignKeys(input, state, true, int64(initial), int64(last))
+	if !reflect.DeepEqual(res, state) {
+		t.Errorf("Expected %v got %v", state, res)
+	}
+	if int64(last) != last2 {
+		t.Errorf("Expected last value to stay at %d but got %d", last, last2)
+	}
+}
+
+func TestChange(t *testing.T) {
+	input := []string{"d", "a", "c"}
+	state := map[string]int64{"a": 5, "b": 6, "c": 7}
+	initial := 5
+	last := state["c"]
+	last2, res := assignKeys(input, state, false, int64(initial), int64(last))
+	expected := map[string]int64{"a": 5, "c": 7, "d": 8}
+	if !reflect.DeepEqual(res, expected) {
+		t.Errorf("Expected %v got %v", state, res)
+	}
+	if int64(last2) != last+1 {
+		t.Errorf("Expected last value to stay at %d but got %d", last, last2)
+	}
+	expected = map[string]int64{"a": 5, "c": 7, "d": 6}
+	last2, res = assignKeys(input, state, true, int64(initial), int64(last))
+	if !reflect.DeepEqual(res, expected) {
+		t.Errorf("Expected %v got %v", state, res)
+	}
+	if int64(last2) != expected["d"] {
+		t.Errorf("Expected last value to stay at %d but got %d", state["b"], last2)
+	}
+}


### PR DESCRIPTION
the new optional `reuse` attribute allows to re-assign freed keys instead of enforcing incremental values.

fixes #50